### PR TITLE
add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "type": "git",
     "url": "https://github.com/lklepner/socket.io-adapter-mongo.git"
   },
+  "license": "MIT",
   "contributors": [
     {
       "name": "Sam Workman",


### PR DESCRIPTION
The npm listing for this package does not specify a license even though this project is MIT licensed. This change should update npm appropriately.